### PR TITLE
add lock for push leaves

### DIFF
--- a/lib/advisory_lock.rb
+++ b/lib/advisory_lock.rb
@@ -1,0 +1,9 @@
+class AdvisoryLock
+  def self.with_transaction_lock(lock_name)
+    lock_id = Zlib.crc32(lock_name.to_s)
+    ActiveRecord::Base.transaction do
+      ActiveRecord::Base.connection.execute("SELECT pg_advisory_xact_lock(#{lock_id})")
+      yield
+    end
+  end
+end

--- a/lib/tasks/benckmark.rake
+++ b/lib/tasks/benckmark.rake
@@ -45,7 +45,7 @@ def do_bm
                     signed_hashed_data: Secp256k1::Util.bin_to_hex(signed_hashed_data.serialized),
                     timestamp: timestamp
     end
-    MerkleNode.push_leaves!(events)
+    MerkleNode.push_leaves_with_lock!(events)
     MerkleNode.untaint! "CHAR", IdentityDigest
   end
 end


### PR DESCRIPTION
Use transaction-level locks. 
* When a transaction commits or rollback, the lock is automatically released. 
* If another transaction with the same session key is initiated, it will wait until the first transaction has released the lock